### PR TITLE
Add OTP Endpoints & Update User Endpoints to Support Phone Numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Unit tests are run via `pytest tests/api`
 
 Integration tests accept a project_id + secret via command line
 ```
-pytest tests/integration/test_integration.py --project_id="***YOUR PROJECT ID***" --secret="***YOUR SECRET KEY***"
+pytest tests/integration/test_integration.py --project_id="***YOUR PROJECT ID***" --secret="***YOUR SECRET KEY***" --email="***YOUR EMAIL***"
 ```
 
 ### Documentation:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = (HERE / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name="stytch",
-    version="1.2.2",
+    version="1.3.0",
     description="Stytch python client",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/stytch/api/base.py
+++ b/stytch/api/base.py
@@ -9,10 +9,39 @@ from .decorator import throw_stytch_exception
 class Base:
     def __init__(self, client):
         self._requester_base = requests
+        self.headers = {'content-type': 'application/json'}
         self.client = client
         self.auth = requests.auth.HTTPBasicAuth(
             self.client.project_id, self.client.secret
         )
+
+    def _validate_attributes(self, attributes: Dict[str, str]) -> Dict[str, str]:
+        if not attributes:
+            return attributes
+        default_attributes = {}
+
+        if attributes.get("ip_address"):
+            default_attributes.update({"ip_address": attributes["ip_address"]})
+        if attributes.get("user_agent"):
+            default_attributes.update({"user_agent": attributes["user_agent"]})
+
+        return default_attributes
+
+    def _validate_options(self, options: Dict[str, bool]) -> Dict[str, bool]:
+        if not options:
+            return options
+
+        default_options = {}
+        if options.get("ip_match_required"):
+            default_options.update(
+                {"ip_match_required": options["ip_match_required"]}
+            )
+        if options.get("user_agent_match_required"):
+            default_options.update(
+                {"user_agent_match_required": options["user_agent_match_required"]}
+            )
+
+        return default_options
 
     def _validate_fields(self, accepted_fields: Set[str], fields: Set[str]) -> bool:
         if len(accepted_fields.union(fields)) > len(accepted_fields):
@@ -25,16 +54,16 @@ class Base:
 
     @throw_stytch_exception
     def _get(self, url: str, query_params: Dict = {}):
-        return self._requester_base.get(url, auth=self.auth, params=query_params)
+        return self._requester_base.get(url, auth=self.auth, headers=self.headers, params=query_params)
 
     @throw_stytch_exception
     def _post(self, url: str, data: Dict):
-        return self._requester_base.post(url, auth=self.auth, data=json.dumps(data))
+        return self._requester_base.post(url, auth=self.auth, headers=self.headers, data=json.dumps(data))
 
     @throw_stytch_exception
     def _put(self, url: str, data: Dict):
-        return self._requester_base.put(url, auth=self.auth, data=json.dumps(data))
+        return self._requester_base.put(url, auth=self.auth, headers=self.headers, data=json.dumps(data))
 
     @throw_stytch_exception
     def _delete(self, url: str):
-        return self._requester_base.delete(url, auth=self.auth)
+        return self._requester_base.delete(url, auth=self.auth, headers=self.headers)

--- a/stytch/api/magic_links.py
+++ b/stytch/api/magic_links.py
@@ -7,11 +7,23 @@ class MagicLinks(Base):
     def magic_link_url(self):
         return self.get_url("magic_links")
 
-    def authenticate(self, token: str, options: Dict = None):
+    def authenticate(
+        self,
+        token: str,
+        attributes: Optional[Dict] = None,
+        options: Optional[Dict] = None,
+    ):
+        attributes = self._validate_attributes(attributes)
         options = self._validate_options(options)
+
+        data={}
+        if attributes:
+            data["attributes"] = attributes
+        if options:
+            data["options"] = options
         return self._post(
             "{0}/{1}/authenticate".format(self.magic_link_url, token),
-            data={"options": options},
+            data=data,
         )
 
     def send(

--- a/stytch/api/magic_links.py
+++ b/stytch/api/magic_links.py
@@ -7,36 +7,8 @@ class MagicLinks(Base):
     def magic_link_url(self):
         return self.get_url("magic_links")
 
-    def _validate_attributes(self, attributes: Dict[str, str]) -> Dict[str, str]:
-        if not attributes:
-            return attributes
-        default_attributes = {"ip_address": "", "user_agent": ""}
-
-        if attributes.get("ip_address"):
-            default_attributes.update({"ip_address": attributes["ip_address"]})
-        if attributes.get("user_agent"):
-            default_attributes.update({"user_agent": attributes["user_agent"]})
-
-        return default_attributes
-
-    def _validate_match_attributes(self, attributes: Dict[str, str]) -> Dict[str, str]:
-        if not attributes:
-            return attributes
-
-        default_attributes = {"ip_address_match": "", "user_agent_match": ""}
-        if attributes.get("ip_address_match"):
-            default_attributes.update(
-                {"ip_address_match": attributes["ip_address_match"]}
-            )
-        if attributes.get("user_agent_match"):
-            default_attributes.update(
-                {"user_agent_match": attributes["user_agent_match"]}
-            )
-
-        return default_attributes
-
     def authenticate(self, token: str, options: Dict = None):
-        options = self._validate_match_attributes(options)
+        options = self._validate_options(options)
         return self._post(
             "{0}/{1}/authenticate".format(self.magic_link_url, token),
             data={"options": options},

--- a/stytch/api/otp.py
+++ b/stytch/api/otp.py
@@ -1,0 +1,80 @@
+from typing import Dict, Optional
+
+from .base import Base
+
+class OTP(Base):
+    @property
+    def otp_url(self):
+        return self.get_url("otp")
+
+    def send_by_sms(
+        self,
+        phone_number: str,
+        expiration_minutes: Optional[int] = None,
+        attributes: Optional[Dict] = None,
+    ):
+        attributes = self._validate_attributes(attributes)
+        data = {
+            "phone_number": phone_number,
+        }
+        if expiration_minutes:
+            data["expiration_minutes"] = expiration_minutes
+        if attributes:
+            data["attributes"] = attributes
+
+        return self._post(
+            "{0}/send_by_sms".format(
+                self.otp_url,
+            ),
+            data=data,
+        )
+
+    def login_or_create_by_sms(
+        self,
+        phone_number: str,
+        expiration_minutes: Optional[int] = None,
+        attributes: Optional[Dict] = None,
+        create_user_as_pending: Optional[bool] = False
+    ):
+        attributes = self._validate_attributes(attributes)
+        data = {
+            "phone_number": phone_number,
+        }
+        if expiration_minutes:
+            data["expiration_minutes"] = expiration_minutes
+        if attributes:
+            data["attributes"] = attributes
+        if create_user_as_pending:
+            data["create_user_as_pending"] = create_user_as_pending
+
+        return self._post(
+            "{0}/login_or_create".format(
+                self.otp_url,
+            ),
+            data=data,
+        )
+
+    def authenticate(
+        self,
+        method_id: str,
+        code: str,
+        attributes: Optional[Dict] = None,
+        options: Optional[Dict] = None
+    ):
+        attributes = self._validate_attributes(attributes)
+        options = self._validate_options(options)
+        data = {
+            "method_id": method_id,
+            "code": code,
+        }
+        if attributes:
+            data["attributes"] = attributes
+        if options:
+            data["options"] = options
+
+        return self._post(
+            "{0}/authenticate".format(
+                self.otp_url,
+            ),
+            data=data,
+        )

--- a/stytch/api/users.py
+++ b/stytch/api/users.py
@@ -96,5 +96,5 @@ class Users(Base):
     def delete_email(self, user_id: str, email: str):
         return self._delete("{0}/{1}/emails/{2}".format(self.user_url, user_id, email))
 
-    def delete_phone_number(self, phone_number_id: str):
-        return self._delete("{0}/phone_numbers/{1}".format(self.user_url, phone_number_id))
+    def delete_phone_number(self, phone_id: str):
+        return self._delete("{0}/phone_numbers/{1}".format(self.user_url, phone_id))

--- a/stytch/api/users.py
+++ b/stytch/api/users.py
@@ -2,7 +2,6 @@ from typing import Dict, Optional
 
 from .base import Base
 
-
 class Users(Base):
     @property
     def user_url(self):
@@ -18,6 +17,7 @@ class Users(Base):
     def create(
         self,
         email: str,
+        phone_number: str = None,
         first_name: str = None,
         last_name: str = None,
         middle_name: str = None,
@@ -25,6 +25,7 @@ class Users(Base):
     ):
         data = {
             "email": email,
+            "phone_number": phone_number,
             "name": {
                 "first_name": first_name,
                 "middle_name": middle_name,
@@ -57,7 +58,8 @@ class Users(Base):
     def update(
         self,
         user_id: str,
-        email: Optional[str] = None,
+        emails: Optional[list[str]] = None,
+        phone_numbers: Optional[list[str]] = None,
         first_name: Optional[str] = None,
         middle_name: Optional[str] = None,
         last_name: Optional[str] = None,
@@ -65,8 +67,6 @@ class Users(Base):
     ):
         data = {}
         name = {}
-        if email:
-            data.update({"email": email})
         if first_name:
             name.update({"first_name": first_name})
         if middle_name:
@@ -75,6 +75,19 @@ class Users(Base):
             name.update({"last_name": last_name})
         if name:
             data.update({"name": name})
+
+        if emails:
+            ems = []
+            for email in emails:
+                ems.append({"email": email})
+            data.update({"emails": ems})
+
+        if phone_numbers:
+            pns = []
+            for phone_number in phone_numbers:
+                pns.append({"phone_number": phone_number})
+            data.update({"phone_numbers": pns})
+
         if attributes and self._validate_attributes(attributes):
             data.update({"attributes": attributes})
 
@@ -82,3 +95,6 @@ class Users(Base):
 
     def delete_email(self, user_id: str, email: str):
         return self._delete("{0}/{1}/emails/{2}".format(self.user_url, user_id, email))
+
+    def delete_phone_number(self, phone_number_id: str):
+        return self._delete("{0}/phone_numbers/{1}".format(self.user_url, phone_number_id))

--- a/stytch/client.py
+++ b/stytch/client.py
@@ -2,7 +2,7 @@ import warnings
 
 from .api.users import Users
 from .api.magic_links import MagicLinks
-
+from .api.otp import OTP
 
 class Client:
     """
@@ -25,6 +25,7 @@ class Client:
 
         self.Users = Users(self)
         self.MagicLinks = MagicLinks(self)
+        self.OTP = OTP(self)
 
     @property
     def base_url(self):


### PR DESCRIPTION
Also fix following issues & bugs:
1. Correct append emails to `User.update` method
2. Fix the `_validate_options` method (formally `_validate_match_attributes`)
3. Set `content-type` header to `application/json`
4. Update README to take in an email