### PR TITLE
dev: Run all tests with pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,4 +20,4 @@ jobs:
         pip install pytest
     - name: Running unit tests
       run: |
-        pytest tests/api
+        pytest

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,7 +10,7 @@ Thanks for contributing to Stytch's Python library! If you run into trouble, fin
 
 ## Testing
 
-Run unit tests with `pytest tests/api`.
+Run unit tests with `pytest`.
 
 ## Issues and Pull Requests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ idna==2.10
 mypy==0.790
 mypy-extensions==0.4.3
 nodeenv==1.5.0
--e git+https://github.com/stytchauth/stytch-python.git@f8b6e5b62e43ef768accb301055085324f33a4f7#egg=PACKAGENAME
 regex==2020.11.11
 requests==2.25.0
 six==1.15.0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,17 +16,16 @@ class TestStytchClient:
             _ = Client("project_id", "secret", "invalid env").base_url
             assert _
 
-    def test_Users_controller_exists(self):
+    def test_users_controller_exists(self):
         client = Client("project_id", "secret", "development", suppress_warnings=True)
-        assert client.Users
-        assert client.Users.get
-        assert client.Users.update
-        assert client.Users.delete
-        assert client.Users.create
+        assert client.users
+        assert client.users.get
+        assert client.users.update
+        assert client.users.delete
+        assert client.users.create
 
-    def test_MagicLinks_controller_exists(self):
+    def test_magic_links_controller_exists(self):
         client = Client("project_id", "secret", "development", suppress_warnings=True)
-        assert client.MagicLinks
-        assert client.MagicLinks.send
-        assert client.MagicLinks.send_by_email
-        assert client.MagicLinks.authenticate
+        assert client.magic_links
+        assert client.magic_links.email.send
+        assert client.magic_links.authenticate


### PR DESCRIPTION
Pytest will automatically discover test files named `test_*.py` and `*_test.py`. By running
`pytest tests/api`, we were skipping any tests at the root of `tests`. This includes some tests
for client setup, which happen to fail because we snake_cased the client namespaces in v4.

This also removes the very old version of `stytch-python` from our `requirements.txt`. Local
development seems to work fine without it, and this allows `pytest` to run to completion in CI.

# Reviewer Notes

The first commit in this PR should fail CI because of non-unique test basenames (a strange
problem). The second commit should fail because we're now running the tests that fail. The last
commit fixes the tests.