### PR TITLE
feat: Add support for OAuth Attach endpoint

### DIFF
--- a/codegen/specs/stytch/oauth.yml
+++ b/codegen/specs/stytch/oauth.yml
@@ -27,3 +27,16 @@ methods:
       session: Optional[StytchSession]
       session_jwt: str
       session_token: str
+  - name: attach
+    method: POST
+    args:
+      - name: provider
+        arg_type: str
+      - name: user_id
+        arg_type: Optional[str] = None
+      - name: session_token
+        arg_type: Optional[str] = None
+      - name: session_jwt
+        arg_type: Optional[str] = None
+    response_type:
+      oauth_attach_token: str

--- a/stytch/api/oauth.py
+++ b/stytch/api/oauth.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional
 
 from stytch.core.api_base import ApiBase
 from stytch.core.http.client import AsyncClient, SyncClient
-from stytch.models.oauth import AuthenticateResponse
+from stytch.models.oauth import AttachResponse, AuthenticateResponse
 
 
 class OAuth:
@@ -93,3 +93,59 @@ class OAuth:
         except Exception:
             pass
         return AuthenticateResponse.from_json(resp.status, json)
+
+    def attach(
+        self,
+        provider: str,
+        user_id: Optional[str] = None,
+        session_token: Optional[str] = None,
+        session_jwt: Optional[str] = None,
+    ) -> AttachResponse:
+        payload: Dict[str, Any] = {
+            "provider": provider,
+        }
+
+        if user_id is not None:
+            payload["user_id"] = user_id
+        if session_token is not None:
+            payload["session_token"] = session_token
+        if session_jwt is not None:
+            payload["session_jwt"] = session_jwt
+
+        url = self.api_base.route_with_sub_url(self.sub_url, "attach")
+
+        resp = self.sync_client.post(url, json=payload)
+        json = {}
+        try:
+            json = resp.json()
+        except Exception:
+            pass
+        return AttachResponse.from_json(resp.status_code, json)
+
+    async def attach_async(
+        self,
+        provider: str,
+        user_id: Optional[str] = None,
+        session_token: Optional[str] = None,
+        session_jwt: Optional[str] = None,
+    ) -> AttachResponse:
+        payload: Dict[str, Any] = {
+            "provider": provider,
+        }
+
+        if user_id is not None:
+            payload["user_id"] = user_id
+        if session_token is not None:
+            payload["session_token"] = session_token
+        if session_jwt is not None:
+            payload["session_jwt"] = session_jwt
+
+        url = self.api_base.route_with_sub_url(self.sub_url, "attach")
+
+        resp = await self.async_client.post(url, json=payload)
+        json = {}
+        try:
+            json = await resp.json()
+        except Exception:
+            pass
+        return AttachResponse.from_json(resp.status, json)

--- a/stytch/models/oauth.py
+++ b/stytch/models/oauth.py
@@ -16,3 +16,7 @@ class AuthenticateResponse(ResponseBase):
     session: Optional[StytchSession]
     session_jwt: str
     session_token: str
+
+
+class AttachResponse(ResponseBase):
+    oauth_attach_token: str


### PR DESCRIPTION
This is a great example of how easy it is to add a new endpoint.

# Development process:
* I edited `oauth.yml` to add the new endpoint
* I ran `bin/generate-api.sh` to run the code generator
* I ran `bin/generate-coverage.sh` to ensure there were no regressions
* I submitted this PR

In an ideal world, I would also add calls to the test API in `test/test_integration.py` and `test/test_integration_async.py`, but there's no test data for this endpoint yet.