### PR TITLE
Add a test for StytchError details

### DIFF
--- a/stytch/core/test/test_models.py
+++ b/stytch/core/test/test_models.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import unittest
 from unittest.mock import create_autospec, patch
 
@@ -111,16 +110,16 @@ class TestModels(unittest.TestCase):
             mock_details.__str__.assert_called_once()
 
     def test_stytcherror_fields(self) -> None:
-        resp = '''{
+        resp = {
           "status_code": 418,
           "request_id": "request-id-test-fea11c44-5514-4aac-a76b-3ca685e3443a",
           "error_type": "is_a_teapot",
           "error_message": "I'm a teapot!",
-          "error_url": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418"
-        }'''
+          "error_url": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418",
+        }
 
         with self.assertRaises(models.StytchError) as e:
-            DummyResponse.from_json(418, json.loads(resp))
+            DummyResponse.from_json(418, resp)
 
         ex = e.exception
         self.assertEqual(ex.details.error_type, "is_a_teapot")

--- a/stytch/core/test/test_models.py
+++ b/stytch/core/test/test_models.py
@@ -127,3 +127,4 @@ class TestModels(unittest.TestCase):
         self.assertEqual(ex.details.status_code, 418)
         self.assertEqual(ex.details.error_url, "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418")
         self.assertEqual(ex.details.error_message, "I'm a teapot!")
+        self.assertEqual(ex.details.request_id, "request-id-test-fea11c44-5514-4aac-a76b-3ca685e3443a")

--- a/stytch/core/test/test_models.py
+++ b/stytch/core/test/test_models.py
@@ -117,13 +117,9 @@ class TestModels(unittest.TestCase):
           "error_message": "I'm a teapot!",
           "error_url": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418",
         }
+        expected = models.StytchErrorDetails(**resp)
 
         with self.assertRaises(models.StytchError) as e:
             DummyResponse.from_json(418, resp)
 
-        ex = e.exception
-        self.assertEqual(ex.details.error_type, "is_a_teapot")
-        self.assertEqual(ex.details.status_code, 418)
-        self.assertEqual(ex.details.error_url, "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418")
-        self.assertEqual(ex.details.error_message, "I'm a teapot!")
-        self.assertEqual(ex.details.request_id, "request-id-test-fea11c44-5514-4aac-a76b-3ca685e3443a")
+        self.assertEqual(e.exception.details, expected)

--- a/stytch/core/test/test_models.py
+++ b/stytch/core/test/test_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import unittest
 from unittest.mock import create_autospec, patch
 
@@ -108,3 +109,21 @@ class TestModels(unittest.TestCase):
             mock_details = create_autospec(models.StytchErrorDetails)
             str(models.StytchError(mock_details))
             mock_details.__str__.assert_called_once()
+
+    def test_stytcherror_fields(self) -> None:
+        resp = '''{
+          "status_code": 418,
+          "request_id": "request-id-test-fea11c44-5514-4aac-a76b-3ca685e3443a",
+          "error_type": "is_a_teapot",
+          "error_message": "I'm a teapot!",
+          "error_url": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418"
+        }'''
+
+        with self.assertRaises(models.StytchError) as e:
+            DummyResponse.from_json(418, json.loads(resp))
+
+        ex = e.exception
+        self.assertEqual(ex.details.error_type, "is_a_teapot")
+        self.assertEqual(ex.details.status_code, 418)
+        self.assertEqual(ex.details.error_url, "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418")
+        self.assertEqual(ex.details.error_message, "I'm a teapot!")


### PR DESCRIPTION
As a way of getting used to the new codebase, I'm adding a test for the bug fixed by #98. This was a very easy test to add!

I tested this test by temporarily reverting the fixed `from_json` and watching the test fail.

I think we should merge this into #98 and then release that.
