### PR TITLE
Add more integration tests

### DIFF
--- a/codegen/types/test/test_method.py
+++ b/codegen/types/test/test_method.py
@@ -45,7 +45,6 @@ class TestMethod(unittest.TestCase):
                 manual_implementation=True,
             ),
         }
-        pass
 
     def test_params_or_json(self) -> None:
         # Act and assert

--- a/codegen/types/test/test_templating.py
+++ b/codegen/types/test/test_templating.py
@@ -2,7 +2,6 @@
 
 import contextlib
 import pathlib
-import shutil
 import tempfile
 import unittest
 

--- a/stytch/core/models.py
+++ b/stytch/core/models.py
@@ -169,6 +169,7 @@ class Password(pydantic.BaseModel):
 
 class User(pydantic.BaseModel):
     name: Optional[Name]
+    user_id: str
     trusted_metadata: Optional[Dict[str, Any]]
     untrusted_metadata: Optional[Dict[str, Any]]
     emails: List[Email]

--- a/stytch/core/test/test_models.py
+++ b/stytch/core/test/test_models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import unittest
-from unittest.mock import create_autospec, patch
+from unittest.mock import create_autospec
 
 from stytch.core import models
 
@@ -72,7 +72,6 @@ class TestModels(unittest.TestCase):
         # Assert
         self.assertTrue(resp.is_redirection)
         self.assertFalse(resp2.is_redirection)
-        pass
 
     def test_is_client_error(self) -> None:
         # Act
@@ -81,7 +80,6 @@ class TestModels(unittest.TestCase):
         # Assert
         self.assertTrue(resp.is_client_error)
         self.assertFalse(resp2.is_client_error)
-        pass
 
     def test_is_server_error(self) -> None:
         # Act


### PR DESCRIPTION
I was updating the integration tests to support a smarter `skipTest` functionality rather than just making a blanket "this isn't always set up, therefore we'll skip it here."

Along the way, I discovered that the model for `User` was missing `user_id`, which seems *pretty* important...