### PR TITLE
Use aiohttp sessions to avoid timeout in search

### DIFF
--- a/bin/search_test.py
+++ b/bin/search_test.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+import asyncio
+import contextlib
+import logging
+import os
+import random
+import string
+import sys
+import time
+from typing import Generator, List
+
+import stytch
+
+
+@contextlib.contextmanager
+def report_elapsed() -> Generator[None, None, None]:
+    start = time.time()
+    try:
+        yield
+    except Exception as e:
+        logging.info(f"Warning: got {e} during timing")
+        raise
+    finally:
+        end = time.time()
+        logging.info(f"Elapsed: {(end - start):.2f} seconds")
+
+
+def sync_search(client: stytch.Client) -> int:
+    search_resp = client.users.search()
+    return len(search_resp.results)
+
+
+async def async_search(client: stytch.Client) -> int:
+    search_resp = await client.users.search_async()
+    return len(search_resp.results)
+
+
+def create_test_users(client: stytch.Client, n: int) -> List[str]:
+    user_ids = []
+    for i in range(1, n + 1):
+        username = "".join(random.choice(string.ascii_letters) for _ in range(20))
+        password = "".join(random.choice(string.printable) for _ in range(24))
+        email = f"{username}@example.com"
+        resp = client.passwords.create(email=email, password=password)
+        user_ids.append(resp.user_id)
+        if i % 10 == 0:
+            logging.debug(f"Created {i} users")
+    return user_ids
+
+
+def delete_test_users(client: stytch.Client, user_ids: List[str]) -> None:
+    for i, user_id in enumerate(user_ids, start=1):
+        client.users.delete(user_id)
+        if i % 10 == 0:
+            logging.debug(f"Deleted {i} users")
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+
+    project_id = os.getenv("STYTCH_PROJECT_ID")
+    secret = os.getenv("STYTCH_SECRET")
+    if project_id is None or secret is None:
+        sys.exit("Missing required env variable")
+
+    client = stytch.Client(project_id, secret, "test")
+
+    logging.info("Deleting existing test users")
+    with report_elapsed():
+        search = client.users.search()
+        logging.info(f"Will delete {len(search.results)} users")
+        delete_test_users(client, [user.user_id for user in search.results])
+
+    logging.info("Creating 100 test users")
+    with report_elapsed():
+        user_ids = create_test_users(client, 100)
+
+    logging.info("Sync search")
+    with report_elapsed():
+        sync_search(client)
+
+    logging.info("Async search")
+    with report_elapsed():
+        asyncio.run(async_search(client))
+
+    logging.info("Deleting test users")
+    with report_elapsed():
+        delete_test_users(client, user_ids)
+
+
+if __name__ == "__main__":
+    main()

--- a/codegen/specs/stytch/magic_links.yml
+++ b/codegen/specs/stytch/magic_links.yml
@@ -14,7 +14,6 @@ methods:
       status_code: int
       request_id: str
       user_id: str
-      email_id: str
   - name: authenticate
     method: POST
     args:

--- a/codegen/types/templates/method.tmpl
+++ b/codegen/types/templates/method.tmpl
@@ -25,16 +25,11 @@ def {{ this.name }}(
     {% endif %}
 
     {% if this.is_delete_method %}
-    resp = self.sync_client.{{ this.method }}(url)
+    res = self.sync_client.{{ this.method }}(url)
     {% else %}
-    resp = self.sync_client.{{ this.method }}(url, {{ this.params_or_json }}=payload)
+    res = self.sync_client.{{ this.method }}(url, {{ this.params_or_json }}=payload)
     {% endif %}
-    json = {}
-    try:
-      json = resp.json()
-    except Exception:
-      pass
-    return {{ this.response_type.name }}.from_json(resp.status_code, json)
+    return {{ this.response_type.name }}.from_json(res.response.status_code, res.json)
 
 async def {{ this.name }}_async(
   self,
@@ -62,16 +57,11 @@ async def {{ this.name }}_async(
     {% endif %}
 
     {% if this.is_delete_method %}
-    resp = await self.async_client.{{ this.method }}(url)
+    res = await self.async_client.{{ this.method }}(url)
     {% else %}
-    resp = await self.async_client.{{ this.method }}(url, {{ this.params_or_json }}=payload)
+    res = await self.async_client.{{ this.method }}(url, {{ this.params_or_json }}=payload)
     {% endif %}
-    json = {}
-    try:
-      json = await resp.json()
-    except Exception:
-      pass
-    return {{ this.response_type.name }}.from_json(resp.status, json)
+    return {{ this.response_type.name }}.from_json(res.response.status, res.json)
 {% else %}
 # MANUAL({{ this.name }})
 def {{ this.name }}(

--- a/codegen/types/test/resources/api.expected
+++ b/codegen/types/test/resources/api.expected
@@ -72,13 +72,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, None)
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-          json = resp.json()
-        except Exception:
-          pass
-        return CreateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return CreateResponse.from_json(res.response.status_code, res.json)
 
     async def create_async(
       self,
@@ -109,13 +104,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, None)
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-          json = await resp.json()
-        except Exception:
-          pass
-        return CreateResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return CreateResponse.from_json(res.response.status, res.json)
 
     def get(
       self,
@@ -128,13 +118,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, user_id)
 
-        resp = self.sync_client.get(url, params=payload)
-        json = {}
-        try:
-          json = resp.json()
-        except Exception:
-          pass
-        return GetResponse.from_json(resp.status_code, json)
+        res = self.sync_client.get(url, params=payload)
+        return GetResponse.from_json(res.response.status_code, res.json)
 
     async def get_async(
       self,
@@ -147,13 +132,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, user_id)
 
-        resp = await self.async_client.get(url, params=payload)
-        json = {}
-        try:
-          json = await resp.json()
-        except Exception:
-          pass
-        return GetResponse.from_json(resp.status, json)
+        res = await self.async_client.get(url, params=payload)
+        return GetResponse.from_json(res.response.status, res.json)
 
     def get_pending(
       self,
@@ -170,13 +150,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "pending")
 
-        resp = self.sync_client.get(url, params=payload)
-        json = {}
-        try:
-          json = resp.json()
-        except Exception:
-          pass
-        return GetPendingResponse.from_json(resp.status_code, json)
+        res = self.sync_client.get(url, params=payload)
+        return GetPendingResponse.from_json(res.response.status_code, res.json)
 
     async def get_pending_async(
       self,
@@ -193,13 +168,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "pending")
 
-        resp = await self.async_client.get(url, params=payload)
-        json = {}
-        try:
-          json = await resp.json()
-        except Exception:
-          pass
-        return GetPendingResponse.from_json(resp.status, json)
+        res = await self.async_client.get(url, params=payload)
+        return GetPendingResponse.from_json(res.response.status, res.json)
 
     def search(
       self,
@@ -219,13 +189,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "search")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-          json = resp.json()
-        except Exception:
-          pass
-        return SearchResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return SearchResponse.from_json(res.response.status_code, res.json)
 
     async def search_async(
       self,
@@ -245,13 +210,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "search")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-          json = await resp.json()
-        except Exception:
-          pass
-        return SearchResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return SearchResponse.from_json(res.response.status, res.json)
 
     # MANUAL(search_all)
     def search_all(
@@ -274,13 +234,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, user_id)
 
-        resp = self.sync_client.delete(url)
-        json = {}
-        try:
-          json = resp.json()
-        except Exception:
-          pass
-        return DeleteResponse.from_json(resp.status_code, json)
+        res = self.sync_client.delete(url)
+        return DeleteResponse.from_json(res.response.status_code, res.json)
 
     async def delete_async(
       self,
@@ -289,13 +244,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, user_id)
 
-        resp = await self.async_client.delete(url)
-        json = {}
-        try:
-          json = await resp.json()
-        except Exception:
-          pass
-        return DeleteResponse.from_json(resp.status, json)
+        res = await self.async_client.delete(url)
+        return DeleteResponse.from_json(res.response.status, res.json)
 
     def update(
       self,
@@ -329,13 +279,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, user_id)
 
-        resp = self.sync_client.put(url, json=payload)
-        json = {}
-        try:
-          json = resp.json()
-        except Exception:
-          pass
-        return UpdateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.put(url, json=payload)
+        return UpdateResponse.from_json(res.response.status_code, res.json)
 
     async def update_async(
       self,
@@ -369,13 +314,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, user_id)
 
-        resp = await self.async_client.put(url, json=payload)
-        json = {}
-        try:
-          json = await resp.json()
-        except Exception:
-          pass
-        return UpdateResponse.from_json(resp.status, json)
+        res = await self.async_client.put(url, json=payload)
+        return UpdateResponse.from_json(res.response.status, res.json)
 
     def delete_email(
       self,
@@ -384,13 +324,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"emails/{email_id}")
 
-        resp = self.sync_client.delete(url)
-        json = {}
-        try:
-          json = resp.json()
-        except Exception:
-          pass
-        return DeleteEmailResponse.from_json(resp.status_code, json)
+        res = self.sync_client.delete(url)
+        return DeleteEmailResponse.from_json(res.response.status_code, res.json)
 
     async def delete_email_async(
       self,
@@ -399,13 +334,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"emails/{email_id}")
 
-        resp = await self.async_client.delete(url)
-        json = {}
-        try:
-          json = await resp.json()
-        except Exception:
-          pass
-        return DeleteEmailResponse.from_json(resp.status, json)
+        res = await self.async_client.delete(url)
+        return DeleteEmailResponse.from_json(res.response.status, res.json)
 
     def delete_phone_number(
       self,
@@ -414,13 +344,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"phone_numbers/{phone_id}")
 
-        resp = self.sync_client.delete(url)
-        json = {}
-        try:
-          json = resp.json()
-        except Exception:
-          pass
-        return DeletePhoneNumberResponse.from_json(resp.status_code, json)
+        res = self.sync_client.delete(url)
+        return DeletePhoneNumberResponse.from_json(res.response.status_code, res.json)
 
     async def delete_phone_number_async(
       self,
@@ -429,13 +354,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"phone_numbers/{phone_id}")
 
-        resp = await self.async_client.delete(url)
-        json = {}
-        try:
-          json = await resp.json()
-        except Exception:
-          pass
-        return DeletePhoneNumberResponse.from_json(resp.status, json)
+        res = await self.async_client.delete(url)
+        return DeletePhoneNumberResponse.from_json(res.response.status, res.json)
 
     def delete_webauthn_registration(
       self,
@@ -444,13 +364,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"webauthn_registrations/{webauthn_registration_id}")
 
-        resp = self.sync_client.delete(url)
-        json = {}
-        try:
-          json = resp.json()
-        except Exception:
-          pass
-        return DeleteWebauthnRegistrationResponse.from_json(resp.status_code, json)
+        res = self.sync_client.delete(url)
+        return DeleteWebauthnRegistrationResponse.from_json(res.response.status_code, res.json)
 
     async def delete_webauthn_registration_async(
       self,
@@ -459,13 +374,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"webauthn_registrations/{webauthn_registration_id}")
 
-        resp = await self.async_client.delete(url)
-        json = {}
-        try:
-          json = await resp.json()
-        except Exception:
-          pass
-        return DeleteWebauthnRegistrationResponse.from_json(resp.status, json)
+        res = await self.async_client.delete(url)
+        return DeleteWebauthnRegistrationResponse.from_json(res.response.status, res.json)
 
     def delete_totp(
       self,
@@ -474,13 +384,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"totps/{totp_id}")
 
-        resp = self.sync_client.delete(url)
-        json = {}
-        try:
-          json = resp.json()
-        except Exception:
-          pass
-        return DeleteTotpResponse.from_json(resp.status_code, json)
+        res = self.sync_client.delete(url)
+        return DeleteTotpResponse.from_json(res.response.status_code, res.json)
 
     async def delete_totp_async(
       self,
@@ -489,13 +394,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"totps/{totp_id}")
 
-        resp = await self.async_client.delete(url)
-        json = {}
-        try:
-          json = await resp.json()
-        except Exception:
-          pass
-        return DeleteTotpResponse.from_json(resp.status, json)
+        res = await self.async_client.delete(url)
+        return DeleteTotpResponse.from_json(res.response.status, res.json)
 
     def delete_crypto_wallet(
       self,
@@ -504,13 +404,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"crypto_wallets/{crypto_wallet_id}")
 
-        resp = self.sync_client.delete(url)
-        json = {}
-        try:
-          json = resp.json()
-        except Exception:
-          pass
-        return DeleteCryptoWalletResponse.from_json(resp.status_code, json)
+        res = self.sync_client.delete(url)
+        return DeleteCryptoWalletResponse.from_json(res.response.status_code, res.json)
 
     async def delete_crypto_wallet_async(
       self,
@@ -519,13 +414,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"crypto_wallets/{crypto_wallet_id}")
 
-        resp = await self.async_client.delete(url)
-        json = {}
-        try:
-          json = await resp.json()
-        except Exception:
-          pass
-        return DeleteCryptoWalletResponse.from_json(resp.status, json)
+        res = await self.async_client.delete(url)
+        return DeleteCryptoWalletResponse.from_json(res.response.status, res.json)
 
     def delete_password(
       self,
@@ -534,13 +424,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"passwords/{password_id}")
 
-        resp = self.sync_client.delete(url)
-        json = {}
-        try:
-          json = resp.json()
-        except Exception:
-          pass
-        return DeletePasswordResponse.from_json(resp.status_code, json)
+        res = self.sync_client.delete(url)
+        return DeletePasswordResponse.from_json(res.response.status_code, res.json)
 
     async def delete_password_async(
       self,
@@ -549,13 +434,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"passwords/{password_id}")
 
-        resp = await self.async_client.delete(url)
-        json = {}
-        try:
-          json = await resp.json()
-        except Exception:
-          pass
-        return DeletePasswordResponse.from_json(resp.status, json)
+        res = await self.async_client.delete(url)
+        return DeletePasswordResponse.from_json(res.response.status, res.json)
 
     def delete_biometric_registration(
       self,
@@ -564,13 +444,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"biometric_registrations/{biometric_registration_id}")
 
-        resp = self.sync_client.delete(url)
-        json = {}
-        try:
-          json = resp.json()
-        except Exception:
-          pass
-        return DeleteBiometricRegistrationResponse.from_json(resp.status_code, json)
+        res = self.sync_client.delete(url)
+        return DeleteBiometricRegistrationResponse.from_json(res.response.status_code, res.json)
 
     async def delete_biometric_registration_async(
       self,
@@ -579,13 +454,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"biometric_registrations/{biometric_registration_id}")
 
-        resp = await self.async_client.delete(url)
-        json = {}
-        try:
-          json = await resp.json()
-        except Exception:
-          pass
-        return DeleteBiometricRegistrationResponse.from_json(resp.status, json)
+        res = await self.async_client.delete(url)
+        return DeleteBiometricRegistrationResponse.from_json(res.response.status, res.json)
 
     def delete_oauth_user_registration(
       self,
@@ -594,13 +464,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"oauth/{oauth_user_registration_id}")
 
-        resp = self.sync_client.delete(url)
-        json = {}
-        try:
-          json = resp.json()
-        except Exception:
-          pass
-        return DeleteOauthUserRegistrationResponse.from_json(resp.status_code, json)
+        res = self.sync_client.delete(url)
+        return DeleteOauthUserRegistrationResponse.from_json(res.response.status_code, res.json)
 
     async def delete_oauth_user_registration_async(
       self,
@@ -609,11 +474,6 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"oauth/{oauth_user_registration_id}")
 
-        resp = await self.async_client.delete(url)
-        json = {}
-        try:
-          json = await resp.json()
-        except Exception:
-          pass
-        return DeleteOauthUserRegistrationResponse.from_json(resp.status, json)
+        res = await self.async_client.delete(url)
+        return DeleteOauthUserRegistrationResponse.from_json(res.response.status, res.json)
 

--- a/codegen/types/test/resources/method.expected
+++ b/codegen/types/test/resources/method.expected
@@ -27,13 +27,8 @@ def create(
 
     url = self.api_base.route_with_sub_url(self.sub_url, None)
 
-    resp = self.sync_client.post(url, json=payload)
-    json = {}
-    try:
-      json = resp.json()
-    except Exception:
-      pass
-    return CreateResponse.from_json(resp.status_code, json)
+    res = self.sync_client.post(url, json=payload)
+    return CreateResponse.from_json(res.response.status_code, res.json)
 
 async def create_async(
   self,
@@ -64,10 +59,5 @@ async def create_async(
 
     url = self.api_base.route_with_sub_url(self.sub_url, None)
 
-    resp = await self.async_client.post(url, json=payload)
-    json = {}
-    try:
-      json = await resp.json()
-    except Exception:
-      pass
-    return CreateResponse.from_json(resp.status, json)
+    res = await self.async_client.post(url, json=payload)
+    return CreateResponse.from_json(res.response.status, res.json)

--- a/stytch/api/crypto_wallets.py
+++ b/stytch/api/crypto_wallets.py
@@ -48,13 +48,8 @@ class CryptoWallets:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate/start")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return AuthenticateStartResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return AuthenticateStartResponse.from_json(res.response.status_code, res.json)
 
     async def authenticate_start_async(
         self,
@@ -78,13 +73,8 @@ class CryptoWallets:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate/start")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return AuthenticateStartResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return AuthenticateStartResponse.from_json(res.response.status, res.json)
 
     def authenticate(
         self,
@@ -113,13 +103,8 @@ class CryptoWallets:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return AuthenticateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return AuthenticateResponse.from_json(res.response.status_code, res.json)
 
     async def authenticate_async(
         self,
@@ -148,10 +133,5 @@ class CryptoWallets:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return AuthenticateResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return AuthenticateResponse.from_json(res.response.status, res.json)

--- a/stytch/api/magic_links.py
+++ b/stytch/api/magic_links.py
@@ -45,13 +45,8 @@ class MagicLinks:
 
         url = self.api_base.route_with_sub_url(self.sub_url, None)
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return CreateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return CreateResponse.from_json(res.response.status_code, res.json)
 
     async def create_async(
         self,
@@ -70,13 +65,8 @@ class MagicLinks:
 
         url = self.api_base.route_with_sub_url(self.sub_url, None)
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return CreateResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return CreateResponse.from_json(res.response.status, res.json)
 
     def authenticate(
         self,
@@ -110,13 +100,8 @@ class MagicLinks:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return AuthenticateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return AuthenticateResponse.from_json(res.response.status_code, res.json)
 
     async def authenticate_async(
         self,
@@ -150,10 +135,5 @@ class MagicLinks:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return AuthenticateResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return AuthenticateResponse.from_json(res.response.status, res.json)

--- a/stytch/api/magic_links_email.py
+++ b/stytch/api/magic_links_email.py
@@ -73,13 +73,8 @@ class Email:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "send")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return SendResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return SendResponse.from_json(res.response.status_code, res.json)
 
     async def send_async(
         self,
@@ -122,13 +117,8 @@ class Email:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "send")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return SendResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return SendResponse.from_json(res.response.status, res.json)
 
     def login_or_create(
         self,
@@ -159,13 +149,8 @@ class Email:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "login_or_create")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return LoginOrCreateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return LoginOrCreateResponse.from_json(res.response.status_code, res.json)
 
     async def login_or_create_async(
         self,
@@ -196,13 +181,8 @@ class Email:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "login_or_create")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return LoginOrCreateResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return LoginOrCreateResponse.from_json(res.response.status, res.json)
 
     def invite(
         self,
@@ -230,13 +210,8 @@ class Email:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "invite")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return InviteResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return InviteResponse.from_json(res.response.status_code, res.json)
 
     async def invite_async(
         self,
@@ -264,13 +239,8 @@ class Email:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "invite")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return InviteResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return InviteResponse.from_json(res.response.status, res.json)
 
     def revoke_invite(
         self,
@@ -282,13 +252,8 @@ class Email:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "revoke_invite")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return RevokeInviteResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return RevokeInviteResponse.from_json(res.response.status_code, res.json)
 
     async def revoke_invite_async(
         self,
@@ -300,10 +265,5 @@ class Email:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "revoke_invite")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return RevokeInviteResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return RevokeInviteResponse.from_json(res.response.status, res.json)

--- a/stytch/api/oauth.py
+++ b/stytch/api/oauth.py
@@ -52,13 +52,8 @@ class OAuth:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return AuthenticateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return AuthenticateResponse.from_json(res.response.status_code, res.json)
 
     async def authenticate_async(
         self,
@@ -86,13 +81,8 @@ class OAuth:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return AuthenticateResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return AuthenticateResponse.from_json(res.response.status, res.json)
 
     def attach(
         self,
@@ -114,13 +104,8 @@ class OAuth:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "attach")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return AttachResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return AttachResponse.from_json(res.response.status_code, res.json)
 
     async def attach_async(
         self,
@@ -142,10 +127,5 @@ class OAuth:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "attach")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return AttachResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return AttachResponse.from_json(res.response.status, res.json)

--- a/stytch/api/otp.py
+++ b/stytch/api/otp.py
@@ -63,13 +63,8 @@ class OTP:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return AuthenticateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return AuthenticateResponse.from_json(res.response.status_code, res.json)
 
     async def authenticate_async(
         self,
@@ -102,10 +97,5 @@ class OTP:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return AuthenticateResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return AuthenticateResponse.from_json(res.response.status, res.json)

--- a/stytch/api/otp_email.py
+++ b/stytch/api/otp_email.py
@@ -55,13 +55,8 @@ class Email:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "send")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return SendResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return SendResponse.from_json(res.response.status_code, res.json)
 
     async def send_async(
         self,
@@ -92,13 +87,8 @@ class Email:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "send")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return SendResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return SendResponse.from_json(res.response.status, res.json)
 
     def login_or_create(
         self,
@@ -122,13 +112,8 @@ class Email:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "login_or_create")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return LoginOrCreateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return LoginOrCreateResponse.from_json(res.response.status_code, res.json)
 
     async def login_or_create_async(
         self,
@@ -152,10 +137,5 @@ class Email:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "login_or_create")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return LoginOrCreateResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return LoginOrCreateResponse.from_json(res.response.status, res.json)

--- a/stytch/api/otp_sms.py
+++ b/stytch/api/otp_sms.py
@@ -55,13 +55,8 @@ class SMS:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "send")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return SendResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return SendResponse.from_json(res.response.status_code, res.json)
 
     async def send_async(
         self,
@@ -92,13 +87,8 @@ class SMS:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "send")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return SendResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return SendResponse.from_json(res.response.status, res.json)
 
     def login_or_create(
         self,
@@ -122,13 +112,8 @@ class SMS:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "login_or_create")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return LoginOrCreateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return LoginOrCreateResponse.from_json(res.response.status_code, res.json)
 
     async def login_or_create_async(
         self,
@@ -152,10 +137,5 @@ class SMS:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "login_or_create")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return LoginOrCreateResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return LoginOrCreateResponse.from_json(res.response.status, res.json)

--- a/stytch/api/otp_whatsapp.py
+++ b/stytch/api/otp_whatsapp.py
@@ -55,13 +55,8 @@ class Whatsapp:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "send")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return SendResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return SendResponse.from_json(res.response.status_code, res.json)
 
     async def send_async(
         self,
@@ -92,13 +87,8 @@ class Whatsapp:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "send")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return SendResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return SendResponse.from_json(res.response.status, res.json)
 
     def login_or_create(
         self,
@@ -122,13 +112,8 @@ class Whatsapp:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "login_or_create")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return LoginOrCreateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return LoginOrCreateResponse.from_json(res.response.status_code, res.json)
 
     async def login_or_create_async(
         self,
@@ -152,10 +137,5 @@ class Whatsapp:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "login_or_create")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return LoginOrCreateResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return LoginOrCreateResponse.from_json(res.response.status, res.json)

--- a/stytch/api/passwords.py
+++ b/stytch/api/passwords.py
@@ -56,13 +56,8 @@ class Passwords:
 
         url = self.api_base.route_with_sub_url(self.sub_url, None)
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return CreateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return CreateResponse.from_json(res.response.status_code, res.json)
 
     async def create_async(
         self,
@@ -83,13 +78,8 @@ class Passwords:
 
         url = self.api_base.route_with_sub_url(self.sub_url, None)
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return CreateResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return CreateResponse.from_json(res.response.status, res.json)
 
     def authenticate(
         self,
@@ -116,13 +106,8 @@ class Passwords:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return AuthenticateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return AuthenticateResponse.from_json(res.response.status_code, res.json)
 
     async def authenticate_async(
         self,
@@ -149,13 +134,8 @@ class Passwords:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return AuthenticateResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return AuthenticateResponse.from_json(res.response.status, res.json)
 
     def strength_check(
         self,
@@ -171,13 +151,8 @@ class Passwords:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "strength_check")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return StrengthCheckResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return StrengthCheckResponse.from_json(res.response.status_code, res.json)
 
     async def strength_check_async(
         self,
@@ -193,13 +168,8 @@ class Passwords:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "strength_check")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return StrengthCheckResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return StrengthCheckResponse.from_json(res.response.status, res.json)
 
     def migrate(
         self,
@@ -228,13 +198,8 @@ class Passwords:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "migrate")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return MigrateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return MigrateResponse.from_json(res.response.status_code, res.json)
 
     async def migrate_async(
         self,
@@ -263,10 +228,5 @@ class Passwords:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "migrate")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return MigrateResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return MigrateResponse.from_json(res.response.status, res.json)

--- a/stytch/api/passwords_email.py
+++ b/stytch/api/passwords_email.py
@@ -57,13 +57,8 @@ class Email:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "reset/start")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return ResetStartResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return ResetStartResponse.from_json(res.response.status_code, res.json)
 
     async def reset_start_async(
         self,
@@ -96,13 +91,8 @@ class Email:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "reset/start")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return ResetStartResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return ResetStartResponse.from_json(res.response.status, res.json)
 
     def reset(
         self,
@@ -138,13 +128,8 @@ class Email:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "reset")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return ResetResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return ResetResponse.from_json(res.response.status_code, res.json)
 
     async def reset_async(
         self,
@@ -180,10 +165,5 @@ class Email:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "reset")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return ResetResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return ResetResponse.from_json(res.response.status, res.json)

--- a/stytch/api/passwords_existing_password.py
+++ b/stytch/api/passwords_existing_password.py
@@ -53,13 +53,8 @@ class ExistingPassword:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "reset")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return ResetResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return ResetResponse.from_json(res.response.status_code, res.json)
 
     async def reset_async(
         self,
@@ -88,10 +83,5 @@ class ExistingPassword:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "reset")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return ResetResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return ResetResponse.from_json(res.response.status, res.json)

--- a/stytch/api/passwords_session.py
+++ b/stytch/api/passwords_session.py
@@ -43,13 +43,8 @@ class Session:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "reset")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return ResetResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return ResetResponse.from_json(res.response.status_code, res.json)
 
     async def reset_async(
         self,
@@ -68,10 +63,5 @@ class Session:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "reset")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return ResetResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return ResetResponse.from_json(res.response.status, res.json)

--- a/stytch/api/sessions.py
+++ b/stytch/api/sessions.py
@@ -45,13 +45,8 @@ class Sessions:
 
         url = self.api_base.route_with_sub_url(self.sub_url, None)
 
-        resp = self.sync_client.get(url, params=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return GetResponse.from_json(resp.status_code, json)
+        res = self.sync_client.get(url, params=payload)
+        return GetResponse.from_json(res.response.status_code, res.json)
 
     async def get_async(
         self,
@@ -63,13 +58,8 @@ class Sessions:
 
         url = self.api_base.route_with_sub_url(self.sub_url, None)
 
-        resp = await self.async_client.get(url, params=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return GetResponse.from_json(resp.status, json)
+        res = await self.async_client.get(url, params=payload)
+        return GetResponse.from_json(res.response.status, res.json)
 
     def authenticate(
         self,
@@ -91,13 +81,8 @@ class Sessions:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return AuthenticateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return AuthenticateResponse.from_json(res.response.status_code, res.json)
 
     async def authenticate_async(
         self,
@@ -119,13 +104,8 @@ class Sessions:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return AuthenticateResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return AuthenticateResponse.from_json(res.response.status, res.json)
 
     # MANUAL(authenticate_jwt)
     def authenticate_jwt(
@@ -268,13 +248,8 @@ class Sessions:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "revoke")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return RevokeResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return RevokeResponse.from_json(res.response.status_code, res.json)
 
     async def revoke_async(
         self,
@@ -293,13 +268,8 @@ class Sessions:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "revoke")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return RevokeResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return RevokeResponse.from_json(res.response.status, res.json)
 
     def jwks(
         self,
@@ -311,13 +281,8 @@ class Sessions:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"jwks/{project_id}")
 
-        resp = self.sync_client.get(url, params=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return JwksResponse.from_json(resp.status_code, json)
+        res = self.sync_client.get(url, params=payload)
+        return JwksResponse.from_json(res.response.status_code, res.json)
 
     async def jwks_async(
         self,
@@ -329,10 +294,5 @@ class Sessions:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"jwks/{project_id}")
 
-        resp = await self.async_client.get(url, params=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return JwksResponse.from_json(resp.status, json)
+        res = await self.async_client.get(url, params=payload)
+        return JwksResponse.from_json(res.response.status, res.json)

--- a/stytch/api/totps.py
+++ b/stytch/api/totps.py
@@ -45,13 +45,8 @@ class TOTPs:
 
         url = self.api_base.route_with_sub_url(self.sub_url, None)
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return CreateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return CreateResponse.from_json(res.response.status_code, res.json)
 
     async def create_async(
         self,
@@ -67,13 +62,8 @@ class TOTPs:
 
         url = self.api_base.route_with_sub_url(self.sub_url, None)
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return CreateResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return CreateResponse.from_json(res.response.status, res.json)
 
     def authenticate(
         self,
@@ -100,13 +90,8 @@ class TOTPs:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return AuthenticateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return AuthenticateResponse.from_json(res.response.status_code, res.json)
 
     async def authenticate_async(
         self,
@@ -133,13 +118,8 @@ class TOTPs:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return AuthenticateResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return AuthenticateResponse.from_json(res.response.status, res.json)
 
     def recovery_codes(
         self,
@@ -151,13 +131,8 @@ class TOTPs:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "recovery_codes")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return RecoveryCodesResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return RecoveryCodesResponse.from_json(res.response.status_code, res.json)
 
     async def recovery_codes_async(
         self,
@@ -169,13 +144,8 @@ class TOTPs:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "recovery_codes")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return RecoveryCodesResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return RecoveryCodesResponse.from_json(res.response.status, res.json)
 
     def recover(
         self,
@@ -202,13 +172,8 @@ class TOTPs:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "recover")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return RecoverResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return RecoverResponse.from_json(res.response.status_code, res.json)
 
     async def recover_async(
         self,
@@ -235,10 +200,5 @@ class TOTPs:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "recover")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return RecoverResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return RecoverResponse.from_json(res.response.status, res.json)

--- a/stytch/api/users.py
+++ b/stytch/api/users.py
@@ -71,13 +71,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, None)
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return CreateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return CreateResponse.from_json(res.response.status_code, res.json)
 
     async def create_async(
         self,
@@ -108,13 +103,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, None)
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return CreateResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return CreateResponse.from_json(res.response.status, res.json)
 
     def get(
         self,
@@ -126,13 +116,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, user_id)
 
-        resp = self.sync_client.get(url, params=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return GetResponse.from_json(resp.status_code, json)
+        res = self.sync_client.get(url, params=payload)
+        return GetResponse.from_json(res.response.status_code, res.json)
 
     async def get_async(
         self,
@@ -144,13 +129,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, user_id)
 
-        resp = await self.async_client.get(url, params=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return GetResponse.from_json(resp.status, json)
+        res = await self.async_client.get(url, params=payload)
+        return GetResponse.from_json(res.response.status, res.json)
 
     def get_pending(
         self,
@@ -166,13 +146,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "pending")
 
-        resp = self.sync_client.get(url, params=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return GetPendingResponse.from_json(resp.status_code, json)
+        res = self.sync_client.get(url, params=payload)
+        return GetPendingResponse.from_json(res.response.status_code, res.json)
 
     async def get_pending_async(
         self,
@@ -188,13 +163,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "pending")
 
-        resp = await self.async_client.get(url, params=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return GetPendingResponse.from_json(resp.status, json)
+        res = await self.async_client.get(url, params=payload)
+        return GetPendingResponse.from_json(res.response.status, res.json)
 
     def search(
         self,
@@ -213,13 +183,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "search")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return SearchResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return SearchResponse.from_json(res.response.status_code, res.json)
 
     async def search_async(
         self,
@@ -238,13 +203,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "search")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return SearchResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return SearchResponse.from_json(res.response.status, res.json)
 
     # MANUAL(search_all)
     def search_all(
@@ -290,13 +250,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, user_id)
 
-        resp = self.sync_client.delete(url)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return DeleteResponse.from_json(resp.status_code, json)
+        res = self.sync_client.delete(url)
+        return DeleteResponse.from_json(res.response.status_code, res.json)
 
     async def delete_async(
         self,
@@ -305,13 +260,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, user_id)
 
-        resp = await self.async_client.delete(url)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return DeleteResponse.from_json(resp.status, json)
+        res = await self.async_client.delete(url)
+        return DeleteResponse.from_json(res.response.status, res.json)
 
     def update(
         self,
@@ -345,13 +295,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, user_id)
 
-        resp = self.sync_client.put(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return UpdateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.put(url, json=payload)
+        return UpdateResponse.from_json(res.response.status_code, res.json)
 
     async def update_async(
         self,
@@ -385,13 +330,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, user_id)
 
-        resp = await self.async_client.put(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return UpdateResponse.from_json(resp.status, json)
+        res = await self.async_client.put(url, json=payload)
+        return UpdateResponse.from_json(res.response.status, res.json)
 
     def delete_email(
         self,
@@ -400,13 +340,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"emails/{email_id}")
 
-        resp = self.sync_client.delete(url)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return DeleteEmailResponse.from_json(resp.status_code, json)
+        res = self.sync_client.delete(url)
+        return DeleteEmailResponse.from_json(res.response.status_code, res.json)
 
     async def delete_email_async(
         self,
@@ -415,13 +350,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"emails/{email_id}")
 
-        resp = await self.async_client.delete(url)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return DeleteEmailResponse.from_json(resp.status, json)
+        res = await self.async_client.delete(url)
+        return DeleteEmailResponse.from_json(res.response.status, res.json)
 
     def delete_phone_number(
         self,
@@ -432,13 +362,8 @@ class Users:
             self.sub_url, f"phone_numbers/{phone_id}"
         )
 
-        resp = self.sync_client.delete(url)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return DeletePhoneNumberResponse.from_json(resp.status_code, json)
+        res = self.sync_client.delete(url)
+        return DeletePhoneNumberResponse.from_json(res.response.status_code, res.json)
 
     async def delete_phone_number_async(
         self,
@@ -449,13 +374,8 @@ class Users:
             self.sub_url, f"phone_numbers/{phone_id}"
         )
 
-        resp = await self.async_client.delete(url)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return DeletePhoneNumberResponse.from_json(resp.status, json)
+        res = await self.async_client.delete(url)
+        return DeletePhoneNumberResponse.from_json(res.response.status, res.json)
 
     def delete_webauthn_registration(
         self,
@@ -466,13 +386,10 @@ class Users:
             self.sub_url, f"webauthn_registrations/{webauthn_registration_id}"
         )
 
-        resp = self.sync_client.delete(url)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return DeleteWebauthnRegistrationResponse.from_json(resp.status_code, json)
+        res = self.sync_client.delete(url)
+        return DeleteWebauthnRegistrationResponse.from_json(
+            res.response.status_code, res.json
+        )
 
     async def delete_webauthn_registration_async(
         self,
@@ -483,13 +400,10 @@ class Users:
             self.sub_url, f"webauthn_registrations/{webauthn_registration_id}"
         )
 
-        resp = await self.async_client.delete(url)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return DeleteWebauthnRegistrationResponse.from_json(resp.status, json)
+        res = await self.async_client.delete(url)
+        return DeleteWebauthnRegistrationResponse.from_json(
+            res.response.status, res.json
+        )
 
     def delete_totp(
         self,
@@ -498,13 +412,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"totps/{totp_id}")
 
-        resp = self.sync_client.delete(url)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return DeleteTotpResponse.from_json(resp.status_code, json)
+        res = self.sync_client.delete(url)
+        return DeleteTotpResponse.from_json(res.response.status_code, res.json)
 
     async def delete_totp_async(
         self,
@@ -513,13 +422,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"totps/{totp_id}")
 
-        resp = await self.async_client.delete(url)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return DeleteTotpResponse.from_json(resp.status, json)
+        res = await self.async_client.delete(url)
+        return DeleteTotpResponse.from_json(res.response.status, res.json)
 
     def delete_crypto_wallet(
         self,
@@ -530,13 +434,8 @@ class Users:
             self.sub_url, f"crypto_wallets/{crypto_wallet_id}"
         )
 
-        resp = self.sync_client.delete(url)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return DeleteCryptoWalletResponse.from_json(resp.status_code, json)
+        res = self.sync_client.delete(url)
+        return DeleteCryptoWalletResponse.from_json(res.response.status_code, res.json)
 
     async def delete_crypto_wallet_async(
         self,
@@ -547,13 +446,8 @@ class Users:
             self.sub_url, f"crypto_wallets/{crypto_wallet_id}"
         )
 
-        resp = await self.async_client.delete(url)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return DeleteCryptoWalletResponse.from_json(resp.status, json)
+        res = await self.async_client.delete(url)
+        return DeleteCryptoWalletResponse.from_json(res.response.status, res.json)
 
     def delete_password(
         self,
@@ -562,13 +456,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"passwords/{password_id}")
 
-        resp = self.sync_client.delete(url)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return DeletePasswordResponse.from_json(resp.status_code, json)
+        res = self.sync_client.delete(url)
+        return DeletePasswordResponse.from_json(res.response.status_code, res.json)
 
     async def delete_password_async(
         self,
@@ -577,13 +466,8 @@ class Users:
 
         url = self.api_base.route_with_sub_url(self.sub_url, f"passwords/{password_id}")
 
-        resp = await self.async_client.delete(url)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return DeletePasswordResponse.from_json(resp.status, json)
+        res = await self.async_client.delete(url)
+        return DeletePasswordResponse.from_json(res.response.status, res.json)
 
     def delete_biometric_registration(
         self,
@@ -594,13 +478,10 @@ class Users:
             self.sub_url, f"biometric_registrations/{biometric_registration_id}"
         )
 
-        resp = self.sync_client.delete(url)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return DeleteBiometricRegistrationResponse.from_json(resp.status_code, json)
+        res = self.sync_client.delete(url)
+        return DeleteBiometricRegistrationResponse.from_json(
+            res.response.status_code, res.json
+        )
 
     async def delete_biometric_registration_async(
         self,
@@ -611,13 +492,10 @@ class Users:
             self.sub_url, f"biometric_registrations/{biometric_registration_id}"
         )
 
-        resp = await self.async_client.delete(url)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return DeleteBiometricRegistrationResponse.from_json(resp.status, json)
+        res = await self.async_client.delete(url)
+        return DeleteBiometricRegistrationResponse.from_json(
+            res.response.status, res.json
+        )
 
     def delete_oauth_user_registration(
         self,
@@ -628,13 +506,10 @@ class Users:
             self.sub_url, f"oauth/{oauth_user_registration_id}"
         )
 
-        resp = self.sync_client.delete(url)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return DeleteOauthUserRegistrationResponse.from_json(resp.status_code, json)
+        res = self.sync_client.delete(url)
+        return DeleteOauthUserRegistrationResponse.from_json(
+            res.response.status_code, res.json
+        )
 
     async def delete_oauth_user_registration_async(
         self,
@@ -645,10 +520,7 @@ class Users:
             self.sub_url, f"oauth/{oauth_user_registration_id}"
         )
 
-        resp = await self.async_client.delete(url)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return DeleteOauthUserRegistrationResponse.from_json(resp.status, json)
+        res = await self.async_client.delete(url)
+        return DeleteOauthUserRegistrationResponse.from_json(
+            res.response.status, res.json
+        )

--- a/stytch/api/webauthn.py
+++ b/stytch/api/webauthn.py
@@ -50,13 +50,8 @@ class WebAuthn:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "register/start")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return RegisterStartResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return RegisterStartResponse.from_json(res.response.status_code, res.json)
 
     async def register_start_async(
         self,
@@ -77,13 +72,8 @@ class WebAuthn:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "register/start")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return RegisterStartResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return RegisterStartResponse.from_json(res.response.status, res.json)
 
     def register(
         self,
@@ -97,13 +87,8 @@ class WebAuthn:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "register")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return RegisterResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return RegisterResponse.from_json(res.response.status_code, res.json)
 
     async def register_async(
         self,
@@ -117,13 +102,8 @@ class WebAuthn:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "register")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return RegisterResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return RegisterResponse.from_json(res.response.status, res.json)
 
     def authenticate_start(
         self,
@@ -137,13 +117,8 @@ class WebAuthn:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate/start")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return AuthenticateStartResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return AuthenticateStartResponse.from_json(res.response.status_code, res.json)
 
     async def authenticate_start_async(
         self,
@@ -157,13 +132,8 @@ class WebAuthn:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate/start")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return AuthenticateStartResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return AuthenticateStartResponse.from_json(res.response.status, res.json)
 
     def authenticate(
         self,
@@ -188,13 +158,8 @@ class WebAuthn:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate")
 
-        resp = self.sync_client.post(url, json=payload)
-        json = {}
-        try:
-            json = resp.json()
-        except Exception:
-            pass
-        return AuthenticateResponse.from_json(resp.status_code, json)
+        res = self.sync_client.post(url, json=payload)
+        return AuthenticateResponse.from_json(res.response.status_code, res.json)
 
     async def authenticate_async(
         self,
@@ -219,10 +184,5 @@ class WebAuthn:
 
         url = self.api_base.route_with_sub_url(self.sub_url, "authenticate")
 
-        resp = await self.async_client.post(url, json=payload)
-        json = {}
-        try:
-            json = await resp.json()
-        except Exception:
-            pass
-        return AuthenticateResponse.from_json(resp.status, json)
+        res = await self.async_client.post(url, json=payload)
+        return AuthenticateResponse.from_json(res.response.status, res.json)

--- a/stytch/models/magic_links.py
+++ b/stytch/models/magic_links.py
@@ -9,7 +9,6 @@ class CreateResponse(ResponseBase):
     status_code: int
     request_id: str
     user_id: str
-    email_id: str
 
 
 class AuthenticateResponse(ResponseBase):


### PR DESCRIPTION
For a large search result, calling `resp.json()` after the session has ended is *very very bad* and will timeout the client.
Verified this now works and is just as fast as the sync API.

Coverage is now at 77%, which is phenomenal. Here's an image of the only untested files (generated with `bin/generate-coverage.sh`)
<img width="763" alt="image" src="https://user-images.githubusercontent.com/119902778/208513607-2927ec46-b81a-4ee3-baac-30c20e965780.png">
