### PR TITLE
Update import statement in Handling Errors section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Structured errors from the Stytch API will raise `StytchError` exceptions. You c
 the `.details` property of the `StytchError` exception.
 
 ```python
-from stytch.api.error import StytchError
+from stytch.core.models import StytchError
 
 try:
     auth_resp = await client.magic_links.authenticate_async(token="token")


### PR DESCRIPTION
Small change to README:

- Previous import statement, no longer works: `from stytch.api.error import StytchError`
- New import statement (≥ v6.0.0): `from stytch.core.models import StytchError`