### PR TITLE
dev: Pin mypy to 0.991 to avoid new errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ autoflake
 # black
 coverage
 isort
-mypy
+mypy==0.991
 pyright
 pyyaml
 types-PyYAML


### PR DESCRIPTION
The newest version of mypy (1.1.1) reports new type errors for unchanged code that currently works. To unblock PRs while we figure this out, this pins mypy to the latest version that previously ran on this repo.

This makes no changes to the actual code in `stytch-python`, so this doesn't get a new version number or dedicated release.