### PR TITLE
Utilize Pydantic V1 API when V2 is Installed

### DIFF
--- a/stytch/api/magic_links_email.py
+++ b/stytch/api/magic_links_email.py
@@ -6,7 +6,10 @@
 
 from typing import Any, Dict, Optional, Union
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except:
+    import pydantic
 
 from stytch.core.api_base import ApiBase
 from stytch.core.http.client import AsyncClient, SyncClient

--- a/stytch/api/magic_links_email.py
+++ b/stytch/api/magic_links_email.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional, Union
 
 try:
     import pydantic.v1 as pydantic
-except:
+except ImportError:
     import pydantic
 
 from stytch.core.api_base import ApiBase

--- a/stytch/api/users.py
+++ b/stytch/api/users.py
@@ -6,7 +6,10 @@
 
 from typing import Any, AsyncGenerator, Dict, Generator, List, Optional, Union
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except:
+    import pydantic
 
 from stytch.core.api_base import ApiBase
 from stytch.core.http.client import AsyncClient, SyncClient

--- a/stytch/api/users.py
+++ b/stytch/api/users.py
@@ -8,7 +8,7 @@ from typing import Any, AsyncGenerator, Dict, Generator, List, Optional, Union
 
 try:
     import pydantic.v1 as pydantic
-except:
+except ImportError:
     import pydantic
 
 from stytch.core.api_base import ApiBase

--- a/stytch/b2b/core/models.py
+++ b/stytch/b2b/core/models.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 
 try:
     import pydantic.v1 as pydantic
-except:
+except ImportError:
     import pydantic
 
 

--- a/stytch/b2b/core/models.py
+++ b/stytch/b2b/core/models.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import datetime
 from typing import Any, Dict, List, Optional
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except:
+    import pydantic
 
 
 class ActiveSSOConnection(pydantic.BaseModel):

--- a/stytch/core/models.py
+++ b/stytch/core/models.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import datetime
 from typing import Any, Dict, List, Optional
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except:
+    import pydantic
 
 
 class ResponseBase(pydantic.BaseModel):

--- a/stytch/core/models.py
+++ b/stytch/core/models.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 
 try:
     import pydantic.v1 as pydantic
-except:
+except ImportError:
     import pydantic
 
 


### PR DESCRIPTION
While `requirements.txt` specifies `pydantic>=1.10.2` stych-python utilizes Pydantic in incompatible ways with the V2 API. This PR makes it so that if pydantic v2 is installed, we explicity utilize the old API by doing `import pydantic as v1` (lets one access v1 in v2), or otherwise import pydantic normally. Currently this issue is stopping me from upgrading a repo to v2, so putting out this fix.