### PR TITLE
Update slack invite links

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -66,4 +66,4 @@ If you have non-trivial changes you'd like us to incorporate, please open an iss
 
 When you're ready for someone to look at your issue or PR, assign `@stytchauth/client-libraries` (GitHub should do this automatically). If we don't acknowledge it within one business day, please escalate it by tagging `@stytchauth/engineering` in a comment or letting us know in [Slack].
 
-[slack]: https://stytch.slack.com/join/shared_invite/zt-2f0fi1ruu-ub~HGouWRmPARM1MTwPESA
+[slack]: https://stytch.com/docs/resources/support/overview

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Follow one of the [integration guides](https://stytch.com/docs/home#guides) or s
 
 If you've found a bug, [open an issue](https://github.com/stytchauth/stytch-python/issues/new)!
 
-If you have questions or want help troubleshooting, join us in [Slack](https://stytch.slack.com/join/shared_invite/zt-2f0fi1ruu-ub~HGouWRmPARM1MTwPESA) or email support@stytch.com.
+If you have questions or want help troubleshooting, join us in [Slack](https://stytch.com/docs/resources/support/overview) or email support@stytch.com.
 
 If you've found a security vulnerability, please follow our [responsible disclosure instructions](https://stytch.com/docs/resources/security-and-trust/security#:~:text=Responsible%20disclosure%20program).
 


### PR DESCRIPTION
Update Slack Invite links to point to the Support landing page as a single source of truth (Slack invite links expire after 400 uses and need to be updated semi frequently).