### PR TITLE
Replace jitterbit/get-changed-files with native git diff

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -31,20 +31,18 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "release_tag=v$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Get changed files
-        id: files
-        uses: jitterbit/get-changed-files@v1
-
       - name: Check for version.py diff
         id: diff
+        env:
+          BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
         run: |
-          FOUND=0
-          for changed_file in ${{ steps.files.outputs.all }}; do
-            if [[ $changed_file == "stytch/version.py" ]]; then
-              FOUND=1
-            fi
-          done
-          echo "diff=$FOUND" >> $GITHUB_OUTPUT
+          git fetch --depth=1 origin "$BASE_SHA"
+          if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- stytch/version.py; then
+            echo "diff=0" >> $GITHUB_OUTPUT
+          else
+            echo "diff=1" >> $GITHUB_OUTPUT
+          fi
 
       - name: Publish distribution to PyPI
         env:


### PR DESCRIPTION
## Summary
- Removes the `jitterbit/get-changed-files@v1` action
- Replaces the two-step "get files + loop to check" pattern with a single step using `git fetch --depth=1` + `git diff --quiet` against `github.event.before`/`github.sha`
- Matches the fix already shipped in stytch-node

## Why
The jitterbit action was deprecated/unmaintained. The native git approach is simpler, has no external dependency, and correctly handles GitHub Actions' shallow clones via the explicit `git fetch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)